### PR TITLE
Fix issue with non-base-10 integer literals in enums

### DIFF
--- a/autopxd/writer.py
+++ b/autopxd/writer.py
@@ -67,7 +67,7 @@ class AutoPxd(c_ast.NodeVisitor, PxdNode):
                         value = '0o' + value[1:]
                 else:
                     # Convert to Python integer if necessary and add one:
-                    if isinstance(value, str):
+                    if isinstance(value, six.string_types):
                         # Remove type suffixes
                         for suffix in 'lLuU':
                             value = value.replace(suffix, '')

--- a/autopxd/writer.py
+++ b/autopxd/writer.py
@@ -60,13 +60,20 @@ class AutoPxd(c_ast.NodeVisitor, PxdNode):
             for item in node.values.enumerators:
                 items.append(item.name)
                 if item.value is not None and hasattr(item.value, 'value'):
+                    # Store the integer literal as a string to preserve its base:
                     value = item.value.value
+                    # convert octal to Python syntax:
                     if value[0] == '0' and len(value) > 1 and value[1] in '0123456789':
-                        # convert octal to Python syntax:
                         value = '0o' + value[1:]
-                    value = int(value, base=0)
                 else:
+                    # Convert to Python integer if necessary and add one:
+                    if isinstance(value, str):
+                        # Remove type suffixes
+                        for suffix in 'lLuU':
+                            value = value.replace(suffix, '')
+                        value = int(value, base=0)
                     value += 1
+                # These constants may be used as array indices:
                 self.constants[item.name] = value
         type_decl = self.child_of(c_ast.TypeDecl, -2)
         type_def = type_decl and self.child_of(c_ast.Typedef, -3)

--- a/autopxd/writer.py
+++ b/autopxd/writer.py
@@ -60,7 +60,11 @@ class AutoPxd(c_ast.NodeVisitor, PxdNode):
             for item in node.values.enumerators:
                 items.append(item.name)
                 if item.value is not None and hasattr(item.value, 'value'):
-                    value = int(item.value.value)
+                    value = item.value.value
+                    if value[0] == '0' and len(value) > 1 and value[1] in '0123456789':
+                        # convert octal to Python syntax:
+                        value = '0o' + value[1:]
+                    value = int(value, base=0)
                 else:
                     value += 1
                 self.constants[item.name] = value

--- a/test/test_files/enum_integer_bases.test
+++ b/test/test_files/enum_integer_bases.test
@@ -1,0 +1,22 @@
+enum MyEnum {
+    C1 = 0xabcd,
+    C2 = 0b01010,
+    C3 = 01234,
+    C4,
+    C5 = 0Xabcd,
+    C6 = 0,
+    C7 = 0B1010
+};
+
+---
+
+cdef extern from "enum_integer_bases.test":
+
+    cdef enum MyEnum:
+        C1
+        C2
+        C3
+        C4
+        C5
+        C6
+        C7

--- a/test/test_files/enum_integer_bases.test
+++ b/test/test_files/enum_integer_bases.test
@@ -3,7 +3,7 @@ enum MyEnum {
     C2 = 0b01010,
     C3 = 01234,
     C4,
-    C5 = 0Xabcd,
+    C5 = 0XabcdL,
     C6 = 0L,
     C7 = 0B1010
 };
@@ -22,4 +22,4 @@ cdef extern from "enum_integer_bases.test":
         C6
         C7
 
-    float my_other_array[0Xabcd][0B1010]
+    float my_other_array[0XabcdL][0B1010]

--- a/test/test_files/enum_integer_bases.test
+++ b/test/test_files/enum_integer_bases.test
@@ -4,10 +4,11 @@ enum MyEnum {
     C3 = 01234,
     C4,
     C5 = 0Xabcd,
-    C6 = 0,
+    C6 = 0L,
     C7 = 0B1010
 };
 
+float my_other_array[C5][C7];
 ---
 
 cdef extern from "enum_integer_bases.test":
@@ -20,3 +21,5 @@ cdef extern from "enum_integer_bases.test":
         C5
         C6
         C7
+
+    float my_other_array[0Xabcd][0B1010]


### PR DESCRIPTION
I encountered the following traceback when running autopxd2:
```
Traceback (most recent call last):
  File "/usr/bin/autopxd", line 10, in <module>
    sys.exit(cli())
  File "/usr/lib/python3.7/site-packages/click/core.py", line 764, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.7/site-packages/click/core.py", line 717, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.7/site-packages/click/core.py", line 956, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.7/site-packages/click/core.py", line 555, in invoke
    return callback(*args, **kwargs)
  File "/usr/lib/python3.7/site-packages/autopxd/__init__.py", line 94, in cli
    outfile.write(translate(infile.read(), infile.name, extra_cpp_args))
  File "/usr/lib/python3.7/site-packages/autopxd/__init__.py", line 73, in translate
    p.visit(parse(code, extra_cpp_args=extra_cpp_args, whitelist=whitelist))
  File "/usr/lib/python3.7/site-packages/autopxd/writer.py", line 20, in visit
    rv = super(AutoPxd, self).visit(node)
  File "/usr/local/lib/python3.7/site-packages/pycparser/c_ast.py", line 158, in visit
    return visitor(node)
  File "/usr/local/lib/python3.7/site-packages/pycparser/c_ast.py", line 165, in generic_visit
    self.visit(c)
  File "/usr/lib/python3.7/site-packages/autopxd/writer.py", line 20, in visit
    rv = super(AutoPxd, self).visit(node)
  File "/usr/local/lib/python3.7/site-packages/pycparser/c_ast.py", line 158, in visit
    return visitor(node)
  File "/usr/lib/python3.7/site-packages/autopxd/writer.py", line 101, in visit_Decl
    decls = self.collect(node)
  File "/usr/lib/python3.7/site-packages/autopxd/writer.py", line 159, in collect
    self.generic_visit(node)
  File "/usr/local/lib/python3.7/site-packages/pycparser/c_ast.py", line 165, in generic_visit
    self.visit(c)
  File "/usr/lib/python3.7/site-packages/autopxd/writer.py", line 20, in visit
    rv = super(AutoPxd, self).visit(node)
  File "/usr/local/lib/python3.7/site-packages/pycparser/c_ast.py", line 158, in visit
    return visitor(node)
  File "/usr/lib/python3.7/site-packages/autopxd/writer.py", line 63, in visit_Enum
    value = int(item.value.value)
ValueError: invalid literal for int() with base 10: '0x20203843'
```

There is an enum in the header file being parsed with a value as a hex literal `0x20203843`, but the code in autopx2 passes that string to `int()` which assumes base 10.

I'm not sure what this part of the code is doing, and why it needs to convert the string representation of the int to a Python int (the result does not end up in the pxd file), but in any case in this PR I've changed it to be able to parse any C integer literal. This means using `int(value, base=0)` to tell it to use the base implied by the prefix of the literal, but also modifying the prefix to match Python syntax when the literal is in octal, since Python and C differ there.