### PR TITLE
Fix failure with nested anonymous enums

### DIFF
--- a/autopxd/writer.py
+++ b/autopxd/writer.py
@@ -70,7 +70,7 @@ class AutoPxd(c_ast.NodeVisitor, PxdNode):
         if not name:
             if type_def:
                 name = self.path_name()
-            elif type_def:
+            elif type_decl:
                 name = self.path_name('e')
         # add the enum definition to the top level
         if node.name is None and type_def and len(items):

--- a/test/test_files/nested_anonymous_enum.test
+++ b/test/test_files/nested_anonymous_enum.test
@@ -1,0 +1,15 @@
+struct nested_enum_struct {
+  enum { a, b, c } x;
+  };
+
+---
+
+cdef extern from "nested_anonymous_enum.test":
+
+    cdef enum _nested_enum_struct_x_e:
+        a
+        b
+        c
+
+    cdef struct nested_enum_struct:
+        _nested_enum_struct_x_e x


### PR DESCRIPTION
With the following C:

```
struct nested_enum_struct {
  enum { a, b, c } x;
  };
```

autopxd2 would fail with:

```
Traceback (most recent call last):
  File "test_renaming.py", line 140, in <module>
    pxd_string += str(p)
  File "/home/bilbo/clones/python-autopxd2/autopxd/nodes.py", line 5, in __str__
    return '\n'.join(self.lines())
  File "/home/bilbo/clones/python-autopxd2/autopxd/writer.py", line 190, in lines
    for line in decl.lines():
  File "/home/bilbo/clones/python-autopxd2/autopxd/nodes.py", line 101, in lines
    for line in field.lines():
AttributeError: 'NoneType' object has no attribute 'lines'

```

This was because of a simple one-line error in writer.py, fixed by this PR. I added a test for it.