### PR TITLE
Allow empty structs and unions

### DIFF
--- a/autopxd/nodes.py
+++ b/autopxd/nodes.py
@@ -96,7 +96,9 @@ class Block(PxdNode):
         self.statement = statement
 
     def lines(self):
-        rv = ['{0} {1} {2}:'.format(self.statement, self.kind, self.name)]
+        rv = ['{0} {1} {2}'.format(self.statement, self.kind, self.name)]
+        if self.fields:
+            rv[0] += ':'
         for field in self.fields:
             for line in field.lines():
                 rv.append(self.indent + line)

--- a/autopxd/writer.py
+++ b/autopxd/writer.py
@@ -41,7 +41,7 @@ class AutoPxd(c_ast.NodeVisitor, PxdNode):
             if self.child_of(c_ast.TypeDecl, -2):
                 # not a definition, must be a reference
                 self.append(name)
-            return
+                return
         fields = self.collect(node)
         # add the struct/union definition to the top level
         if type_def and node.name is None:

--- a/autopxd/writer.py
+++ b/autopxd/writer.py
@@ -60,7 +60,11 @@ class AutoPxd(c_ast.NodeVisitor, PxdNode):
             for item in node.values.enumerators:
                 items.append(item.name)
                 if item.value is not None and hasattr(item.value, 'value'):
-                    value = int(item.value.value)
+                    value = item.value.value
+                    if value[0] == '0' and len(value) > 1 and value[1] in '0123456789':
+                        # convert octal to Python syntax:
+                        value = '0o' + value[1:]
+                    value = int(value, base=0)
                 else:
                     value += 1
                 self.constants[item.name] = value

--- a/test/test_files/empty_block.test
+++ b/test/test_files/empty_block.test
@@ -1,0 +1,11 @@
+struct foo;
+union baz;
+
+---
+
+cdef extern from "empty_block.test":
+
+    cdef struct foo
+
+    cdef union baz
+    

--- a/test/test_files/enum_integer_bases.test
+++ b/test/test_files/enum_integer_bases.test
@@ -1,0 +1,22 @@
+enum MyEnum {
+    C1 = 0xabcd,
+    C2 = 0b01010,
+    C3 = 01234,
+    C4,
+    C5 = 0Xabcd,
+    C6 = 0,
+    C7 = 0B1010
+};
+
+---
+
+cdef extern from "enum_integer_bases.test":
+
+    cdef enum MyEnum:
+        C1
+        C2
+        C3
+        C4
+        C5
+        C6
+        C7

--- a/test/test_files/forward_empty_struct.test
+++ b/test/test_files/forward_empty_struct.test
@@ -11,6 +11,8 @@ struct my_struct {
 
 cdef extern from "forward_empty_struct.test":
 
+    cdef struct my_struct
+
     void my_func(my_struct*, int a)
 
     cdef struct my_struct:

--- a/test/test_files/whitelist.test
+++ b/test/test_files/whitelist.test
@@ -4,6 +4,8 @@
 
 cdef extern from "whitelist.test":
 
+    cdef struct tux
+
     void foo(tux*, int a)
 
     cdef struct tux:


### PR DESCRIPTION
Structs can be empty in GCC, so allow them. This change also allows empty unions - I am not sure if they are legal, but if they are in the header file they will be in the Cython (Cython does not complain about them).

Do not bother to remove empty structs/unions that are forward definitions. They
are superfluous, but are legal Cython, and it would add complexity to remove
them.

Added a test explicitly for empty structs and unions, and modified two tests that expected empty structs from forward definitions to have been removed to instead expect them to remain.

This isn't just academic, I am using a library that has empty structs. Or at least, they are empty as written in the header file.