### PR TITLE
Produce a valid (if empty) pxd if header file has no declarations.

### DIFF
--- a/autopxd/writer.py
+++ b/autopxd/writer.py
@@ -219,4 +219,7 @@ class AutoPxd(c_ast.NodeVisitor, PxdNode):
             for line in decl.lines():
                 rv.append(self.indent + line)
             rv.append('')
+        if len(rv) == 2:
+            rv[1] = self.indent + 'pass'
+            rv.append('')
         return rv

--- a/test/test_files/no_declarations.test
+++ b/test/test_files/no_declarations.test
@@ -1,0 +1,6 @@
+#define foo 1.0
+
+---
+
+cdef extern from "no_declarations.test":
+    pass


### PR DESCRIPTION
By adding 'pass' after the 'cdef extern from' line.