### PR TITLE
Allow inline function definitions

### DIFF
--- a/autopxd/__init__.py
+++ b/autopxd/__init__.py
@@ -50,7 +50,7 @@ def parse(code, extra_cpp_args=[], whitelist=None):
     ast = parser.parse(preprocessed)
     decls = []
     for decl in ast.ext:
-        if hasattr(decl, 'name') and decl.name not in IGNORE_DECLARATIONS:
+        if not hasattr(decl, 'name') or decl.name not in IGNORE_DECLARATIONS:
             if not whitelist or decl.coord.file in whitelist:
                 decls.append(decl)
     ast.ext = decls

--- a/autopxd/writer.py
+++ b/autopxd/writer.py
@@ -182,6 +182,10 @@ class AutoPxd(c_ast.NodeVisitor, PxdNode):
         if names[0] != names[1]:
             self.decl_stack[0].append(Type(decls[0]))
 
+    def visit_Compound(self, node):
+        # Do not recurse into the body of inline function definitions
+        pass
+
     def collect(self, node):
         decls = []
         self.decl_stack.append(decls)

--- a/test/test_files/funcdef.test
+++ b/test/test_files/funcdef.test
@@ -1,0 +1,9 @@
+static inline int foo(int z) {
+    return 2*z;
+}
+
+---
+
+cdef extern from "funcdef.test":
+
+    int foo(int z)

--- a/test/test_files/funcdef.test
+++ b/test/test_files/funcdef.test
@@ -1,9 +1,15 @@
+int bar(int x);
+
 static inline int foo(int z) {
-    return 2*z;
+    int y;
+    y = 2 * z;
+    return bar(y);
 }
 
 ---
 
 cdef extern from "funcdef.test":
+
+    int bar(int x)
 
     int foo(int z)


### PR DESCRIPTION
These were previously skipped over by the code that ignored declarations
by name, because the function definition nodes do not have a name attribute.
Modified the logic to not exclude nodes that do not have names.