### PR TITLE
Split tests into one fixture per test

### DIFF
--- a/test/test_autopxd.py
+++ b/test/test_autopxd.py
@@ -5,11 +5,11 @@ import pytest
 import autopxd
 
 
-def test_all():
-    files_dir = os.path.join(os.path.dirname(__file__), "test_files")
-    list_to_test = list(glob.iglob(files_dir + '/*.test'))
-    print(len(list_to_test), 'files to test')
-    for file_path in list_to_test:
+FILES_DIR = os.path.join(os.path.dirname(__file__), "test_files")
+
+
+def make_test(file_path):
+    def test_func():
         with open(file_path) as f:
             data = f.read()
         c, cython = re.split('^-+$', data, maxsplit=1, flags=re.MULTILINE)
@@ -18,13 +18,21 @@ def test_all():
 
         whitelist = None
         cpp_args = []
-        if file_path == files_dir + '/whitelist.test':
+        if file_path == FILES_DIR + '/whitelist.test':
             test_path = os.path.dirname(file_path)
-            whitelist = [files_dir + '/tux_foo.h']
+            whitelist = [FILES_DIR + '/tux_foo.h']
             cpp_args = ['-I', test_path]
         actual = autopxd.translate(c, os.path.basename(file_path), cpp_args, whitelist)
         assert cython == actual
 
+    test_func_name = 'test_' + os.path.basename(file_path).replace('.test', '')
+    test_func.__name__ = test_func_name
+    globals()[test_func_name] = test_func
+
+
+# Populate globals with one fixture for each test
+for file_path in glob.iglob(FILES_DIR + '/*.test'):
+    make_test(file_path)
 
 if __name__ == '__main__':
     pytest.main([__file__])


### PR DESCRIPTION
This makes it easier to see which test(s) failed, rather than the whole
thing being a single test fixture.