### PR TITLE
OSX Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,4 +104,5 @@ venv.bak/
 .mypy_cache/
 
 autopxd/include/*
+autopxd/darwin-include/*
 *.pyc

--- a/autopxd/declarations.py
+++ b/autopxd/declarations.py
@@ -1,6 +1,11 @@
 import os
 
 BUILTIN_HEADERS_DIR = os.path.join(os.path.dirname(__file__), 'include')
+
+# Stubs for /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include
+DARWIN_HEADERS_DIR = os.path.join(os.path.dirname(__file__), 'darwin-include')
+
+
 # Types declared by pycparser fake headers that we should ignore
 IGNORE_DECLARATIONS = {'size_t', '__builtin_va_list', '__gnuc_va_list', '__int8_t',
                        '__uint8_t', '__int16_t', '__uint16_t', '__int_least16_t',

--- a/autopxd/declarations.py
+++ b/autopxd/declarations.py
@@ -2,7 +2,7 @@ import os
 
 BUILTIN_HEADERS_DIR = os.path.join(os.path.dirname(__file__), 'include')
 
-# Stubs for /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include
+# Stubs for /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include  # noqa
 DARWIN_HEADERS_DIR = os.path.join(os.path.dirname(__file__), 'darwin-include')
 
 

--- a/setup.py
+++ b/setup.py
@@ -56,15 +56,21 @@ def install_libc_headers_and(cmdclass):
 
     return Sub
 
+
 VERSION = '1.0.0'
 REPO = 'https://github.com/gabrieldemarmiesse/python-autopxd2'
+
+PACKAGE_DATA = ['include/*.h', 'include/**/*.h']
+
+if platform.system() == 'Darwin':
+    PACKAGE_DATA += ['darwin-include/*.h', 'darwin-include/**/*.h']
 
 setup(
     name='autopxd2',
     version=VERSION,
     description='Automatically generate Cython pxd files from C headers',
     packages=['autopxd'],
-    package_data={'autopxd': ['include/*.h', 'include/**/*.h', 'darwin-include/*.h', 'darwin-include/**/*.h']},
+    package_data={'autopxd': PACKAGE_DATA},
     author='Gabriel de Marmiesse',
     author_email='gabrieldemarmiesse@gmail.com',
     url=REPO,

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,14 @@
 import os
+import platform
 import subprocess
 
 from setuptools import setup
 from setuptools.command.develop import develop
 from setuptools.command.install import install
 from setuptools.command.sdist import sdist
+
+
+DARWIN_INCLUDE = '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/'
 
 
 def install_libc_headers_and(cmdclass):
@@ -25,13 +29,32 @@ def install_libc_headers_and(cmdclass):
                                   'pycparser-{2}/utils/fake_libc_include/'
                               ).format(inc, url, commit), shell=True)
 
+    def generate_fake_darwin_include():
+        if not os.path.exists(DARWIN_INCLUDE):
+            return
+        inc = os.path.join('./autopxd', 'darwin-include')
+        if os.path.exists(inc):
+            if not os.path.isdir(inc):
+                raise Exception(
+                    '"{0}" already exists and is not a directory'.format(inc))
+            return
+        for root, dirs, files in os.walk(DARWIN_INCLUDE):
+            for file in files:
+                root = root.replace(DARWIN_INCLUDE, '')
+                stub = os.path.join(inc, root, file)
+                print('Stubbing %s' % stub)
+                os.makedirs(os.path.join(inc, root), exist_ok=True)
+                with open(stub, 'w') as f:
+                    f.write('#include "_fake_defines.h"\n#include "_fake_typedefs.h"')
+
     class Sub(cmdclass):
         def run(self):
             download_fake_libc_include()
+            if platform.system() == 'Darwin':
+                generate_fake_darwin_include()
             cmdclass.run(self)
 
     return Sub
-
 
 VERSION = '1.0.0'
 REPO = 'https://github.com/gabrieldemarmiesse/python-autopxd2'
@@ -41,7 +64,7 @@ setup(
     version=VERSION,
     description='Automatically generate Cython pxd files from C headers',
     packages=['autopxd'],
-    package_data={'autopxd': ['include/*.h', 'include/**/*.h']},
+    package_data={'autopxd': ['include/*.h', 'include/**/*.h', 'darwin-include/*.h', 'darwin-include/**/*.h']},
     author='Gabriel de Marmiesse',
     author_email='gabrieldemarmiesse@gmail.com',
     url=REPO,

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ from setuptools.command.install import install
 from setuptools.command.sdist import sdist
 
 
-DARWIN_INCLUDE = '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/'
+DARWIN_INCLUDE = '/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform' \
+                 '/Developer/SDKs/MacOSX.sdk/usr/include/'
 
 
 def install_libc_headers_and(cmdclass):


### PR DESCRIPTION
This adds support for OSX via the following:

* OSX SDK headers are stubbed
* `clang -E` is used as the C preprocessor rather than `cpp`
* `clang -E` seems to barf if passed `-I /some/path`, it needs `-I/some/path`, so I've updated those args.