### PR TITLE
fix CRLF issue on Windows

### DIFF
--- a/autopxd/__init__.py
+++ b/autopxd/__init__.py
@@ -53,7 +53,7 @@ def preprocess(code, extra_cpp_args=[], debug=False):
     res = b''.join(result).decode('utf-8')
     if debug:
         sys.stderr.write(res)
-    return res
+    return res.replace('\r\n', '\n')
 
 
 def parse(code, extra_cpp_args=[], whitelist=None, debug=False):


### PR DESCRIPTION
Autopxd will produce error "... pycparser.plyparser.ParseError: :1:14: invalid #line directive" on Microsoft Windows 7 / 10 + mingw-w64, while the same header file works correctly on Linux & MacOS.
The difference between windows and unix-like os is that function "preprocess" (autopxd \_\_init\_\_.py) returns an output containing CRLF on Windows.
Replacing CRLF with LF in function "preprocess" will fix the issue on Windows.
