### PR TITLE
Support const & volatile qualifiers

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,17 +17,15 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python-version: '3.6.15'
+            python-version: '3.7'
           - os: ubuntu-latest
-            python-version: '3.7.14'
+            python-version: '3.8'
           - os: ubuntu-latest
-            python-version: '3.8.14'
+            python-version: '3.9'
           - os: ubuntu-latest
-            python-version: '3.9.14'
-          - os: ubuntu-latest
-            python-version: '3.10.7'
+            python-version: '3.10'
           - os: macos-latest
-            python-version: '3.10.7'
+            python-version: '3.10'
 
     steps:
       - name: Checkout code

--- a/autopxd/nodes.py
+++ b/autopxd/nodes.py
@@ -3,6 +3,7 @@ from abc import (
     abstractmethod,
 )
 from typing import (
+    Iterable,
     List,
     Union,
 )
@@ -63,13 +64,18 @@ class Ptr(IdentifierType):
 
     node: PxdNode
 
-    def __init__(self, node: IdentifierType):
+    def __init__(self, node: IdentifierType, quals: Iterable[str] = ()):
         self.node = node
         if isinstance(node, Function):
             type_name = node.return_type
         else:
             type_name = self.node.type_name
-        super().__init__(self.node.name, f"{type_name}*")
+        type_name = f"{type_name}*"
+        # Cython supports const and volatile C type qualifiers
+        for qual in ("const", "volatile"):
+            if qual in quals:
+                type_name = f"{type_name} {qual}"
+        super().__init__(self.node.name, type_name)
 
     def lines(self) -> List[str]:
         if isinstance(self.node, Function):

--- a/autopxd/writer.py
+++ b/autopxd/writer.py
@@ -153,6 +153,10 @@ class AutoPxd(c_ast.NodeVisitor, PxdNode):
         if not decls:
             return
         assert len(decls) == 1
+        # Cython supports const and volatile C type qualifiers
+        for qual in ("const", "volatile"):
+            if qual in node.quals:
+                decls[0] = f"{qual} {decls[0]}"
         if isinstance(decls[0], str):
             include_C_name = not self.child_of(c_ast.ParamList)
             self.append(IdentifierType(escape(node.declname, include_C_name), decls[0]))
@@ -189,9 +193,13 @@ class AutoPxd(c_ast.NodeVisitor, PxdNode):
         decls = self.collect(node)
         assert len(decls) == 1
         if isinstance(decls[0], str):
+            # Cython supports const and volatile C type qualifiers
+            for qual in ("const", "volatile"):
+                if qual in node.quals:
+                    decls[0] = f"{qual} {decls[0]}"
             self.append(decls[0])
         else:
-            self.append(Ptr(decls[0]))
+            self.append(Ptr(decls[0], node.quals))
 
     def visit_ArrayDecl(self, node):
         dim = ""

--- a/test/test_files/c_qualifiers.test
+++ b/test/test_files/c_qualifiers.test
@@ -1,0 +1,85 @@
+struct my_struct {
+  const int a, b;
+  int const c;
+  const char *d;
+  char const *e;
+  char * const f;
+  const char const *g;  // "const char const" is equivalent to "const char"
+  char const * const h;
+  char const * const * const i;
+  const char ** const j;
+};
+
+union my_union {
+    const int *a;
+    int * const b;
+    const struct my_struct c;
+    const struct my_struct *d;
+    const struct my_struct * const e;
+};
+
+const int *(*my_func_ptr_1)();
+int * const(*my_func_ptr_2)();
+const int const * const(*my_func_ptr_3)();
+void const(*my_func_ptr_4)(const int *a, const int * const b, const int const * const c, const struct my_struct d, const union my_union *e);
+
+const int *my_func_1();
+int const *my_func_2();
+const int const *my_func_3();
+int * const my_func_4();
+const int const * const my_func_5();
+void my_func_6(const struct my_struct *s, const union my_union const * const u);
+void my_func_7(const char *a1, char const * const *a2, char ** const a3[3][4]);
+
+---
+
+cdef extern from "c_qualifiers.test":
+
+    cdef struct my_struct:
+        const int a
+        const int b
+        const int c
+        const char* d
+        const char* e
+        char* const f
+        const char* g
+        const char* const h
+        const char* const* const i
+        const char** const j
+
+    cdef union my_union:
+        const int* a
+        int* const b
+        const my_struct c
+        const my_struct* d
+        const my_struct* const e
+
+    ctypedef const int* (*_my_func_ptr_1_ft)()
+
+    _my_func_ptr_1_ft my_func_ptr_1
+
+    ctypedef int* const (*_my_func_ptr_2_ft)()
+
+    _my_func_ptr_2_ft my_func_ptr_2
+
+    ctypedef const int* const (*_my_func_ptr_3_ft)()
+
+    _my_func_ptr_3_ft my_func_ptr_3
+
+    ctypedef const void (*_my_func_ptr_4_ft)(const int* a, const int* const b, const int* const c, const my_struct d, const my_union* e)
+
+    _my_func_ptr_4_ft my_func_ptr_4
+
+    const int* my_func_1()
+
+    const int* my_func_2()
+
+    const int* my_func_3()
+
+    int* const my_func_4()
+
+    const int* const my_func_5()
+
+    void my_func_6(const my_struct* s, const my_union* const u)
+
+    void my_func_7(const char* a1, const char* const* a2, char** const a3[3][4])

--- a/test/test_files/xnvme_opts.test
+++ b/test/test_files/xnvme_opts.test
@@ -46,12 +46,12 @@ cdef extern from "xnvme_opts.test":
         uint32_t given
 
     cdef struct xnvme_opts:
-        char* be
-        char* dev
-        char* mem
-        char* sync
-        char* async_ "async"
-        char* admin
+        const char* be
+        const char* dev
+        const char* mem
+        const char* sync
+        const char* async_ "async"
+        const char* admin
         uint32_t nsid
         uint32_t create_mode
         uint8_t poll_io
@@ -62,8 +62,8 @@ cdef extern from "xnvme_opts.test":
         uint32_t use_cmb_sqs
         uint32_t shm_id
         uint32_t main_core
-        char* core_mask
-        char* adrfam
+        const char* core_mask
+        const char* adrfam
         uint32_t spdk_fabrics
         uint32_t oflags
         uint32_t rdonly


### PR DESCRIPTION
I'm using autopxd2 to parse the [Godot](godotengine.org/) [C API](https://github.com/touilleMan/godot-python/blob/9f9353bd013d0c8a68b5f4a1c99aa74f7f65beed/godot_headers/godot/gdextension_interface.h) as part of [Godot-Python](https://github.com/touilleMan/godot-python) project. However this C API contains type definitions with const which get stripped in the generated pxd, [resulting in warning during compilation](https://github.com/touilleMan/godot-python/blob/9f9353bd013d0c8a68b5f4a1c99aa74f7f65beed/src/godot/hazmat/gdapi_pxd/meth.pxd.j2#L61-L63).

(I've also update the CI given Python 3.6 is no [longer available on Github 
Actions](https://github.com/touilleMan/python-autopxd2/actions/runs/3832795846/jobs/6523520699#step:3:10))