### PR TITLE
Fixed an issue where character values in enum could not be handled in some cases.

### DIFF
--- a/autopxd/writer.py
+++ b/autopxd/writer.py
@@ -117,9 +117,13 @@ class AutoPxd(c_ast.NodeVisitor, PxdNode):
                 else:
                     # Convert to Python integer if necessary and add one:
                     if isinstance(value, str):
-                        # Remove type suffixes
-                        for suffix in "lLuU":
-                            value = value.replace(suffix, "")
+                        if "'" in value:
+                            # Handle characters
+                            value = str(int.from_bytes(value[1:-1].encode('raw_unicode_escape')))
+                        else:
+                            # Remove type suffixes
+                            for suffix in "lLuU":
+                                value = value.replace(suffix, "")
                     value = str(int(value, base=0) + 1)
                 # These constants may be used as array indices:
                 self.constants[item.name] = value


### PR DESCRIPTION
Fixed an issue where character values in enum could not be handled in some cases like
``` c
// test.h 
typedef enum
{
    SDL_SCANCODE_CAPSLOCK = 57,
} SDL_Scancode;

#define SDLK_SCANCODE_MASK (1<<30)
#define SDL_SCANCODE_TO_KEYCODE(X)  (X | SDLK_SCANCODE_MASK)

typedef enum
{
    SDLK_z = 'z',
    SDLK_CAPSLOCK = SDL_SCANCODE_TO_KEYCODE(SDL_SCANCODE_CAPSLOCK),
} SDL_KeyCode;
```
``` shell
File "D:/msys64/ucrt64/lib/python3.11/site-packages/autopxd/writer.py", line 125, in visit_Enum
    value = str(int(value, base=0) + 1)
                ^^^^^^^^^^^^^^^^^^
ValueError: invalid literal for int() with base 0: "'z'"
```