### PR TITLE
Move setup requirements to pyproject.toml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,6 +26,8 @@ jobs:
         run: |
           npm install -g lintball@v1.5.0
           lintball install-tools --yes
+          # Lintball install Black==22.3.0 which doesn't support Python >= 3.11
+          `npm root -g`/lintball/tools/python-env/bin/pip install black==24.8.0
 
       - name: Check for linter issues
         run: lintball check

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,7 +23,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.10'
+          python-version: '3.12'
 
       - name: Build sdist
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,15 +17,15 @@ jobs:
       matrix:
         include:
           - os: ubuntu-latest
-            python-version: '3.7'
-          - os: ubuntu-latest
-            python-version: '3.8'
-          - os: ubuntu-latest
             python-version: '3.9'
           - os: ubuntu-latest
             python-version: '3.10'
+          - os: ubuntu-latest
+            python-version: '3.11'
+          - os: ubuntu-latest
+            python-version: '3.12'
           - os: macos-latest
-            python-version: '3.10'
+            python-version: '3.12'
 
     steps:
       - name: Checkout code
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest]
-        python-version: ['3.10']
+        python-version: ['3.12']
 
     steps:
       - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ It generates `.pxd` files automatically from `.h` files.
 
 #### Tested against:
 
-- Python 3.7
-- Python 3.8
 - Python 3.9
 - Python 3.10
+- Python 3.11
+- Python 3.12
 
 [![Test](https://github.com/elijahr/python-autopxd2/actions/workflows/test.yml/badge.svg)](https://github.com/elijahr/python-autopxd2/actions/workflows/test.yml)
 [![Lint](https://github.com/elijahr/python-autopxd2/actions/workflows/lint.yml/badge.svg)](https://github.com/elijahr/python-autopxd2/actions/workflows/lint.yml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ build-backend = "setuptools.build_meta"
 line_length = 120
 target_version = ["py39", "py310", "py311", "py312"]
 preview = true
-required_version = "22.3.0"
+required_version = "24.8.0"
 
 [tool.autopep8]
 exclude = ".git,__pycache__"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ build-backend = "setuptools.build_meta"
 # black-compatible configurations for various Python code formatters.
 # Assembled from https://black.readthedocs.io/en/stable/compatible_configs.html
 line_length = 120
-target_version = ["py37", "py38", "py39", "py310"]
+target_version = ["py39", "py310", "py311", "py312"]
 preview = true
 required_version = "22.3.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,15 @@
-# black-compatible configurations for various Python code formatters.
-# Assembled from https://black.readthedocs.io/en/stable/compatible_configs.html
+[build-system]
+requires = [
+  "wheel",
+  # Setuptools 18.0 properly handles Cython extensions.
+  "setuptools>=18.0",
+  "cython"
+]
+build-backend = "setuptools.build_meta"
 
 [tool.black]
+# black-compatible configurations for various Python code formatters.
+# Assembled from https://black.readthedocs.io/en/stable/compatible_configs.html
 line_length = 120
 target_version = ["py37", "py38", "py39", "py310"]
 preview = true

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,11 +22,6 @@ classifiers =
 [options]
 packages = autopxd
 python_requires = >=3.6, <4
-setup_requires =
-  wheel
-  # Setuptools 18.0 properly handles Cython extensions.
-  setuptools>=18.0
-  cython
 install_requires =
   Click
   pycparser


### PR DESCRIPTION
Following PEP 517, we need to define the build requirements in the `pyproject.toml`, rather than the `setup.cfg`. This is generally because `setup.cfg` is configuration for Setuptools, but Python doesn't even know to use Setuptools unless it's declared in the `pyproject.toml`.

Anyway, this fixes the following error that I was previously getting:

```bash
$  pip install autopxd2               
Collecting autopxd2
  Using cached autopxd2-2.3.0.tar.gz (22 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [17 lines of output]
      Traceback (most recent call last):
        File "/home/migwell/Programming/pinnacl/venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/home/migwell/Programming/pinnacl/venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/home/migwell/Programming/pinnacl/venv/lib/python3.10/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-vusnfmq9/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 325, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=['wheel'])
        File "/tmp/pip-build-env-vusnfmq9/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 295, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-vusnfmq9/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 487, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-vusnfmq9/overlay/lib/python3.10/site-packages/setuptools/build_meta.py", line 311, in run_setup
          exec(code, locals())
        File "<string>", line 18, in <module>
      ModuleNotFoundError: No module named 'wheel'
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```