### PR TITLE
Windows build: fix vswhere.exe command to find cl.exe

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,12 +2,7 @@
 
 name: Test
 
-on:
-  push:
-    branches:
-      - '*'
-    tags:
-      - '*'
+on: [push, pull_request]
 
 jobs:
   test-unix:

--- a/autopxd/__init__.py
+++ b/autopxd/__init__.py
@@ -56,6 +56,8 @@ def _find_cl():
         os.path.join(program_files, r"Microsoft Visual Studio\Installer\vswhere.exe"),
         "-prerelease",
         "-latest",
+        "-products",
+        "*",
         "-format",
         "json",
         "-utf8",


### PR DESCRIPTION
The '-products *' option is now necessary to find cl.exe.