### PR TITLE
binary operator raise exception

### DIFF
--- a/autopxd/writer.py
+++ b/autopxd/writer.py
@@ -63,7 +63,21 @@ def parse_enum_value(node):
             assert False, f"Unsuported constant type for enum value: {node}"
 
     elif isinstance(node, c_ast.BinaryOp):
-        value_as_str = f"{node.left.name} {node.op} {node.right.name}"
+        if isinstance(node.left, c_ast.Constant):
+            nodeleft = parse_enum_value(node.left)[0]
+        elif hasattr(node.left, "name"):
+            nodeleft = node.left.name
+        else:
+            assert False, f"Unsuported expression for enum value: {node.left}"
+
+        if isinstance(node.right, c_ast.Constant):
+            noderight = parse_enum_value(node.right)[0]
+        elif hasattr(node.right, "name"):
+            noderight = node.right.name
+        else:
+            assert False, f"Unsuported expression for enum value: {node.right}"
+
+        value_as_str = f"{nodeleft} {node.op} {noderight}"
         value_as_int = None
 
     else:

--- a/test/test_files/enum_integer_bases.test
+++ b/test/test_files/enum_integer_bases.test
@@ -10,6 +10,7 @@ enum MyEnum {
     C9 = C1 + C2,
     C10,
     C11,
+    C12 = 5 + 6,
 };
 
 float my_array_c1[C1];
@@ -23,6 +24,7 @@ float my_array_c8[C8];
 float my_array_c9[C9];
 float my_array_c10[C10];
 float my_array_c11[C11];
+float my_array_c12[C12];
 ---
 
 cdef extern from "enum_integer_bases.test":
@@ -39,6 +41,7 @@ cdef extern from "enum_integer_bases.test":
         C9
         C10
         C11
+        C12
 
     float my_array_c1[0xabcd]
 
@@ -61,3 +64,5 @@ cdef extern from "enum_integer_bases.test":
     float my_array_c10[C1 + C2 + 1]
 
     float my_array_c11[C1 + C2 + 2]
+
+    float my_array_c12[5 + 6]


### PR DESCRIPTION
it can be that node.left.name or node.right.name not exist

Traceback (most recent call last):
  File "/home/dionisio/.local/bin/autopxd", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1157, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1078, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 1434, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/click/core.py", line 783, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dionisio/.local/lib/python3.12/site-packages/autopxd/__init__.py", line 286, in cli
    outfile.write(translate(infile.read(), infile.name, extra_cpp_args, debug=debug, regex=regex))
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dionisio/.local/lib/python3.12/site-packages/autopxd/__init__.py", line 207, in translate
    p.visit(
  File "/home/dionisio/.local/lib/python3.12/site-packages/autopxd/writer.py", line 93, in visit
    rv = super().visit(node)
         ^^^^^^^^^^^^^^^^^^^
  File "/home/dionisio/.local/lib/python3.12/site-packages/pycparser/c_ast.py", line 158, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/home/dionisio/.local/lib/python3.12/site-packages/pycparser/c_ast.py", line 165, in generic_visit
    self.visit(c)
  File "/home/dionisio/.local/lib/python3.12/site-packages/autopxd/writer.py", line 93, in visit
    rv = super().visit(node)
         ^^^^^^^^^^^^^^^^^^^
  File "/home/dionisio/.local/lib/python3.12/site-packages/pycparser/c_ast.py", line 158, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/home/dionisio/.local/lib/python3.12/site-packages/autopxd/writer.py", line 266, in visit_Typedef
    decls = self.collect(node)
            ^^^^^^^^^^^^^^^^^^
  File "/home/dionisio/.local/lib/python3.12/site-packages/autopxd/writer.py", line 284, in collect
    self.generic_visit(node)
  File "/home/dionisio/.local/lib/python3.12/site-packages/pycparser/c_ast.py", line 165, in generic_visit
    self.visit(c)
  File "/home/dionisio/.local/lib/python3.12/site-packages/autopxd/writer.py", line 93, in visit
    rv = super().visit(node)
         ^^^^^^^^^^^^^^^^^^^
  File "/home/dionisio/.local/lib/python3.12/site-packages/pycparser/c_ast.py", line 158, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/home/dionisio/.local/lib/python3.12/site-packages/autopxd/writer.py", line 200, in visit_TypeDecl
    decls = self.collect(node)
            ^^^^^^^^^^^^^^^^^^
  File "/home/dionisio/.local/lib/python3.12/site-packages/autopxd/writer.py", line 284, in collect
    self.generic_visit(node)
  File "/home/dionisio/.local/lib/python3.12/site-packages/pycparser/c_ast.py", line 165, in generic_visit
    self.visit(c)
  File "/home/dionisio/.local/lib/python3.12/site-packages/autopxd/writer.py", line 93, in visit
    rv = super().visit(node)
         ^^^^^^^^^^^^^^^^^^^
  File "/home/dionisio/.local/lib/python3.12/site-packages/pycparser/c_ast.py", line 158, in visit
    return visitor(node)
           ^^^^^^^^^^^^^
  File "/home/dionisio/.local/lib/python3.12/site-packages/autopxd/writer.py", line 158, in visit_Enum
    value_as_str, maybe_value_as_int = parse_enum_value(item.value)
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/dionisio/.local/lib/python3.12/site-packages/autopxd/writer.py", line 73, in parse_enum_value
    value_as_str = f"{node.left.name} {node.op} {node.right.name}"
                      ^^^^^^^^^^^^^^
AttributeError: 'Constant' object has no attribute 'name'