### PR TITLE
Ship complete sdist, add release verification gate, prep 3.2.3

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
         run: python -m build
 
       - name: Install verification tools
-        run: uv pip install --system check-manifest twine
+        run: uv pip install --system check-manifest==0.51 twine==6.2.0
 
       - name: Verify sdist completeness
         run: check-manifest --verbose

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -37,6 +37,15 @@ jobs:
       - name: Build sdist and wheel
         run: python -m build
 
+      - name: Install verification tools
+        run: uv pip install --system check-manifest twine
+
+      - name: Verify sdist completeness
+        run: check-manifest --verbose
+
+      - name: Validate distribution metadata
+        run: twine check --strict dist/*
+
       - name: Upload distribution artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,12 @@ repos:
         additional_dependencies:
           - pycparser
           - click
+
+  - repo: https://github.com/mgedmin/check-manifest
+    rev: "0.51"
+    hooks:
+      - id: check-manifest
+        args: [--no-build-isolation]
+        additional_dependencies:
+          - setuptools
+          - wheel

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,5 +31,5 @@ repos:
       - id: check-manifest
         args: [--no-build-isolation]
         additional_dependencies:
-          - setuptools
+          - setuptools>=61
           - wheel

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.2.3] - 2026-06-05
+
+### Fixed
+- **Incomplete source distribution** - The PyPI sdist now ships the full test
+  suite, including helper modules (`test/assertions.py`, `test/cython_utils.py`,
+  `test/conftest.py`, `test/header_cache.py`, `test/library_detection.py`),
+  fixtures, and data directories. Previously these were omitted, causing
+  `ModuleNotFoundError: No module named 'test.assertions'` when downstream
+  packagers ran the tests from the sdist (NixOS/nixpkgs#524341). The release
+  workflow now runs `check-manifest` and `twine check --strict` before publishing
+  so an incomplete sdist cannot ship again.
+
+  Note for downstream packagers without network access: the `real_headers` tests
+  download library headers at runtime and must be deselected with
+  `pytest -m "not real_headers"`.
+- **Missing runtime stub in wheel and sdist** - Ship
+  `autopxd/stubs/darwin-include/.supports-builtin-modules` in both the wheel and
+  the sdist. The `stubs/darwin-include/**/*` package-data glob silently skipped
+  leading-dot files, so this runtime include-tree stub was missing from every
+  previous wheel.
+
 ## [3.2.2] - 2025-12-19
 
 ### Fixed
@@ -179,7 +200,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - macOS support
 
-[Unreleased]: https://github.com/elijahr/python-autopxd2/compare/v3.2.0...HEAD
+[Unreleased]: https://github.com/elijahr/python-autopxd2/compare/v3.2.3...HEAD
+[3.2.3]: https://github.com/elijahr/python-autopxd2/compare/v3.2.2...v3.2.3
+[3.2.2]: https://github.com/elijahr/python-autopxd2/compare/v3.2.1...v3.2.2
+[3.2.1]: https://github.com/elijahr/python-autopxd2/compare/v3.2.0...v3.2.1
 [3.2.0]: https://github.com/elijahr/python-autopxd2/compare/v3.1.1...v3.2.0
 [3.1.1]: https://github.com/elijahr/python-autopxd2/compare/v3.1.0...v3.1.1
 [3.1.0]: https://github.com/elijahr/python-autopxd2/compare/v3.0.0...v3.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,6 +158,24 @@ This section is for project maintainers who can publish releases.
    git push origin master
    ```
 
+> **Important:** The git ref you release from (the tag, or the SHA passed to
+> the manual `workflow_dispatch`) MUST contain the `pyproject.toml` version
+> bump. `workflow_dispatch` accepts an arbitrary ref and will happily build
+> and publish from a ref that lacks the bump.
+
+### Sdist completeness guard
+
+The publish workflow builds the sdist and wheel, then runs `check-manifest`
+and `twine check --strict` **before** uploading the distribution artifacts. If
+the sdist is missing any version-controlled file that belongs in it (for
+example, a new test helper or fixture), `check-manifest` fails, the `build`
+job fails, and because `publish-pypi` depends on `build`, nothing is published.
+
+`check-manifest` also runs locally via pre-commit, so drift is usually caught
+before you push. If it flags a new file, update `MANIFEST.in` (to ship it) or
+the `[tool.check-manifest]` `ignore` list in `pyproject.toml` (to keep it out
+of the sdist) — never weaken the gate to make it pass.
+
 ### 2. Create a GitHub Release
 
 1. Go to [Releases](https://github.com/elijahr/python-autopxd2/releases)

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,10 +4,8 @@
 # suite from the sdist. See NixOS/nixpkgs#524341.
 
 # --- Test suite: helpers, fixtures, and data (the fix) ---
-recursive-include test *.py
-recursive-include test *.test *.cpptest
-recursive-include test *.h *.hpp *.pxd
-recursive-include test *.gitkeep
+# Ship the entire tracked test tree; byte-compiled cruft is excluded below.
+graft test
 
 # --- Runtime stub dotfile dropped by setuptools globbing ---
 # The "stubs/darwin-include/**/*" package-data glob does not match leading-dot
@@ -21,7 +19,7 @@ include CONTRIBUTING.md
 include regenerate_stubs.py
 
 # --- Test-library install helpers referenced by test/test_real_headers.py ---
-recursive-include scripts *.sh
+graft scripts
 
 # --- Repo-only infrastructure: never ship ---
 exclude .gitignore
@@ -31,3 +29,7 @@ exclude Dockerfile
 exclude mkdocs.yml
 prune .github
 prune docs
+
+# --- Hygiene: keep graft from sweeping byte-compiled cruft ---
+global-exclude *.py[cod]
+global-exclude __pycache__

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -30,6 +30,5 @@ exclude mkdocs.yml
 prune .github
 prune docs
 
-# --- Hygiene: keep graft from sweeping byte-compiled cruft ---
+# --- Hygiene: keep graft from sweeping byte-compiled files ---
 global-exclude *.py[cod]
-global-exclude __pycache__

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,33 @@
+# Sdist content spec. The wheel is unaffected (include_package_data is not set;
+# packages are controlled by [tool.setuptools.packages.find]).
+# Ship the complete test tree so downstream packagers (e.g. nixpkgs) can run the
+# suite from the sdist. See NixOS/nixpkgs#524341.
+
+# --- Test suite: helpers, fixtures, and data (the fix) ---
+recursive-include test *.py
+recursive-include test *.test *.cpptest
+recursive-include test *.h *.hpp *.pxd
+recursive-include test *.gitkeep
+
+# --- Runtime stub dotfile dropped by setuptools globbing ---
+# The "stubs/darwin-include/**/*" package-data glob does not match leading-dot
+# files, so the sdist's default include misses this tracked stub. It is read at
+# runtime (clang -I include path), so ship it explicitly.
+include autopxd/stubs/darwin-include/.supports-builtin-modules
+
+# --- Top-level docs/metadata worth shipping in source form ---
+include CHANGELOG.md
+include CONTRIBUTING.md
+include regenerate_stubs.py
+
+# --- Test-library install helpers referenced by test/test_real_headers.py ---
+recursive-include scripts *.sh
+
+# --- Repo-only infrastructure: never ship ---
+exclude .gitignore
+exclude .dockerignore
+exclude .pre-commit-config.yaml
+exclude Dockerfile
+exclude mkdocs.yml
+prune .github
+prune docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
 name = "autopxd2"
-version = "3.2.2"
+version = "3.2.3"
 description = "Automatically generate Cython pxd files from C headers"
 readme = "README.md"
 license = { file = "LICENSE" }
@@ -67,6 +67,11 @@ autopxd = [
   "stubs/include/**/*",
   "stubs/darwin-include/*",
   "stubs/darwin-include/**/*",
+  # Leading-dot files are not matched by the "*" globs above (setuptools
+  # mirrors shell semantics where "*" skips dotfiles). This stub is consumed
+  # at runtime via the clang -I include path (declarations.py /
+  # pycparser_backend.py), so it must ship in the wheel as well as the sdist.
+  "stubs/darwin-include/.supports-builtin-modules",
 ]
 
 [tool.ruff]
@@ -119,4 +124,15 @@ markers = [
     "pycparser: tests/parameterizations using the pycparser backend",
     "libclang: tests/parameterizations using the libclang backend (includes C++ tests)",
     "real_headers: tests against real system libraries (requires library installation)",
+]
+
+[tool.check-manifest]
+ignore = [
+    ".gitignore",
+    ".dockerignore",
+    ".pre-commit-config.yaml",
+    "Dockerfile",
+    "mkdocs.yml",
+    ".github/**",
+    "docs/**",
 ]


### PR DESCRIPTION
Fixes the incomplete PyPI sdist: 3.2.2's tarball omitted the test helper modules (`test/assertions.py`, `test/cython_utils.py`, `test/conftest.py`, and others) and data dirs (`test/fixtures/`, `test/real_headers/`, `test/regressions/`), so downstream packagers running tests from the sdist hit `ModuleNotFoundError: No module named 'test.assertions'` at collection.

What's here:

- **MANIFEST.in** — explicit sdist spec: full `test/` tree, `scripts/`, top-level docs. The sdist now mirrors `git ls-files` (verified: 97/97 tracked test files present; `pytest --collect-only` on the extracted sdist collects with 0 errors).
- **Ship-guard** — `check-manifest` and `twine check --strict` run in the publish workflow's build job between build and artifact upload; `publish-pypi` has `needs: build`, so a failed gate blocks publishing on both triggers (release and workflow_dispatch). Tool versions pinned (`check-manifest==0.51`, `twine==6.2.0`). An advisory `check-manifest` pre-commit hook (rev 0.51, `--no-build-isolation`) runs locally and in PR CI; it carries `additional_dependencies: [setuptools, wheel]` because with `--no-build-isolation` the hook env must supply the build backend — a deliberate addition beyond the original design notes.
- **Wheel fix (intentional wheel change)** — `autopxd/stubs/darwin-include/.supports-builtin-modules` is tracked in git and lives in the runtime clang include tree, but the `stubs/darwin-include/**/*` package-data glob skips leading-dot files, so it was missing from every previous wheel. It now ships in both wheel and sdist. This supersedes the working design's "wheel untouched" assumption: the 3.2.3 wheel intentionally gains exactly this one file vs 3.2.2.
- **Release prep** — version 3.2.3; Keep-a-Changelog entry, including a note that downstream packagers without network access must deselect the `real_headers` tests (`pytest -m "not real_headers"`); CHANGELOG footer compare-links retargeted and backfilled; CONTRIBUTING gains a ship-guard subsection and a warning that the `workflow_dispatch` ref must contain the version bump.
- **Build floor** — `build-system.requires` pinned to `setuptools>=61` (PEP 621 `[project]` metadata floor).

Local verification: `check-manifest` exit 0; `twine check --strict` PASSED for both artifacts; wheel file-list diff vs the 3.2.2 baseline shows exactly the one intended added file; targeted pytest subset 49/49 passing on the bumped package; negative controls confirm the gate actually fails on injected manifest breakage.

After merge: create the GitHub Release v3.2.3 from a ref containing the version bump (per CONTRIBUTING); the publish workflow builds, gates, and publishes.
